### PR TITLE
yychr: off-by-one on 8 -> 24 bit copy

### DIFF
--- a/clip_win.cpp
+++ b/clip_win.cpp
@@ -401,7 +401,7 @@ bool lock::impl::get_image(image& output_img) const {
           (bi->bmiColors[c].rgbBlue  << spec.blue_shift);
       }
 
-      char* src = (((char*)bi)+bi->bmiHeader.biSize+sizeof(RGBQUAD)*colors);
+      unsigned char* src = (((unsigned char*)bi)+bi->bmiHeader.biSize+sizeof(RGBQUAD)*colors);
       int padding = (4-(spec.width&3))&3;
 
       for (long y=spec.height-1; y>=0; --y, src+=padding) {
@@ -444,6 +444,9 @@ bool lock::impl::get_image_spec(image_spec& spec) const {
   if (spec.bits_per_pixel <= 8)
     spec.bits_per_pixel = 24;
   spec.bytes_per_row = w*((spec.bits_per_pixel+7)/8);
+  if (spec.bits_per_pixel == 24) {
+    spec.bytes_per_row++; // XXX hack to avoid off-by-one on 32bit handling
+  }
 
   switch (spec.bits_per_pixel) {
 

--- a/clip_win.cpp
+++ b/clip_win.cpp
@@ -393,28 +393,23 @@ bool lock::impl::get_image(image& output_img) const {
 
     case 8: {
       int colors = (bi->bmiHeader.biClrUsed > 0 ? bi->bmiHeader.biClrUsed: 256);
-      std::vector<uint32_t> palette(colors);
-      for (int c=0; c<colors; ++c) {
-        palette[c] =
-          (bi->bmiColors[c].rgbRed   << spec.red_shift) |
-          (bi->bmiColors[c].rgbGreen << spec.green_shift) |
-          (bi->bmiColors[c].rgbBlue  << spec.blue_shift);
-      }
 
-      char* src = (((char*)bi)+bi->bmiHeader.biSize+sizeof(RGBQUAD)*colors);
+      unsigned char* src = (((unsigned char*)bi)+bi->bmiHeader.biSize+sizeof(RGBQUAD)*colors);
       int padding = (4-(spec.width&3))&3;
 
       for (long y=spec.height-1; y>=0; --y, src+=padding) {
-        char* dst = img.data()+y*spec.bytes_per_row;
+        unsigned char* dst = (unsigned char*)(img.data())+y*spec.bytes_per_row;
 
-        for (unsigned long x=0; x<spec.width; ++x, ++src, dst+=3) {
-          int idx = *src;
+        for (unsigned long x=0; x<spec.width; ++x) {
+          int idx = *(src++);
           if (idx < 0)
             idx = 0;
           else if (idx >= colors)
             idx = colors-1;
 
-          *((uint32_t*)dst) = palette[idx];
+          *(dst++) = bi->bmiColors[idx].rgbBlue;
+          *(dst++) = bi->bmiColors[idx].rgbGreen;
+          *(dst++) = bi->bmiColors[idx].rgbRed;
         }
       }
       break;


### PR DESCRIPTION
It seems that the `*((uint32_t*)dst) = palette[idx]` was setting the bytes skewed and causing an off-by-one on the allocated memory for the image. I did a quick test with the sample supplied by the yychr program and it worked, maybe you can get more test samples at the original issue aseprite/aseprite#1206.

page (japanese): http://www.geocities.jp/yy_6502/yychr/
binary: http://www.geocities.jp/yy_6502/yychr/yychr_net.zip