### PR TITLE
Add a new clip::has() function that allows to specify an error handling function avoiding the use of the default one

### DIFF
--- a/clip.h
+++ b/clip.h
@@ -24,6 +24,22 @@ namespace clip {
   class image;
   struct image_spec;
 
+  // ======================================================================
+  // Error handling
+  // ======================================================================
+
+  enum class ErrorCode {
+    CannotLock,
+    ImageNotSupported,
+  };
+
+  typedef void (*error_handler)(ErrorCode code);
+
+  void set_error_handler(error_handler f);
+  error_handler get_error_handler();
+
+  #define OMIT_LOCKING_ERROR nullptr
+
   class lock {
   public:
     // You can give your current HWND as the "native_window_handle."
@@ -33,6 +49,12 @@ namespace clip {
     // EmptyClipboard() call. Anyway it looks to work just fine if we
     // call OpenClipboard() with a null HWND.
     lock(void* native_window_handle = nullptr);
+    // Creates a lock where you can specify an error handler to use
+    // when the clipboad implementation requires locking it first and
+    // we couldn't get the lock. Also, we can specify the number of
+    // times we want to try to get the clipboard lock and how many
+    // milliseconds we want to wait between tries.
+    lock(error_handler e, int tries, int sleepms, void* native_window_handle = nullptr);
     ~lock();
 
     // Returns true if we've locked the clipboard successfully in
@@ -75,22 +97,14 @@ namespace clip {
   // Returns true if the clipboard has content of the given type.
   bool has(format f);
 
+  // The same as has(format f) but you can specify an error handler when the
+  // clipboard cannot be locked, along with the number of locking tries and
+  // waiting period between tries.
+  bool has(format f, error_handler e, int tries, int sleepms);
+
+
   // Clears the clipboard content.
   bool clear();
-
-  // ======================================================================
-  // Error handling
-  // ======================================================================
-
-  enum class ErrorCode {
-    CannotLock,
-    ImageNotSupported,
-  };
-
-  typedef void (*error_handler)(ErrorCode code);
-
-  void set_error_handler(error_handler f);
-  error_handler get_error_handler();
 
   // ======================================================================
   // Text

--- a/clip_lock_impl.h
+++ b/clip_lock_impl.h
@@ -12,6 +12,7 @@ namespace clip {
 class lock::impl {
 public:
   impl(void* native_window_handle);
+  impl(void* native_window_handle, int tries, int sleepms);
   ~impl();
 
   bool locked() const { return m_locked; }

--- a/clip_none.cpp
+++ b/clip_none.cpp
@@ -19,7 +19,10 @@ typedef std::map<format, Buffer> Map;
 static format g_last_format = 100; // TODO create an enum with common formats
 static Map g_data;
 
-lock::impl::impl(void* native_handle) : m_locked(true) {
+lock::impl::impl(void*, int tries, int sleepms) : m_locked(true) {
+}
+
+lock::impl::impl(void* native_handle) : impl(native_handle, 0, 0) {
 }
 
 lock::impl::~impl() {

--- a/clip_osx.mm
+++ b/clip_osx.mm
@@ -132,7 +132,10 @@ namespace {
 
 }
 
-lock::impl::impl(void*) : m_locked(true) {
+lock::impl::impl(void*, int tries, int sleepms) : m_locked(true) {
+}
+
+lock::impl::impl(void*) : impl(nullptr, 0, 0) {
 }
 
 lock::impl::~impl() {

--- a/clip_win.cpp
+++ b/clip_win.cpp
@@ -207,20 +207,17 @@ struct BitmapInfo {
 
 }
 
-lock::impl::impl(void* hwnd) : m_locked(false) {
-  for (int i=0; i<5; ++i) {
+lock::impl::impl(void* hwnd, int tries, int sleepms) : m_locked(false) {
+  for (int i = 0; i < tries; ++i) {
     if (OpenClipboard((HWND)hwnd)) {
       m_locked = true;
       break;
     }
-    Sleep(20);
+    Sleep(sleepms);
   }
+}
 
-  if (!m_locked) {
-    error_handler e = get_error_handler();
-    if (e)
-      e(ErrorCode::CannotLock);
-  }
+lock::impl::impl(void* hwnd) : impl(hwnd, 5, 20) {
 }
 
 lock::impl::~impl() {


### PR DESCRIPTION
This is introduced because sometimes the caller might want to handle the locking error that might arise in a different way than the current error handler does.
Related to:
aseprite/aseprite#4016
